### PR TITLE
Maven-friendly environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ build/
 *.obj
 *.mtl
 *.fbx
+
+## Maven
+target

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -25,6 +25,12 @@
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-backend-android</artifactId>
         </dependency>
+
+        <!-- http://source.android.com -->
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.mygdx.game</groupId>
+        <artifactId>gdx-demo-3d</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>android</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+    </build>
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,20 +10,24 @@
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>android</artifactId>
+    <artifactId>core</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
-        <!-- https://github.com/antivoland/GdxDemo3D -->
-        <dependency>
-            <groupId>com.mygdx.game</groupId>
-            <artifactId>core</artifactId>
-        </dependency>
-
         <!-- https://github.com/libgdx/libgdx -->
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
-            <artifactId>gdx-backend-android</artifactId>
+            <artifactId>gdx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-bullet</artifactId>
+        </dependency>
+
+        <!-- https://github.com/libgdx/gdx-ai -->
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-ai</artifactId>
         </dependency>
     </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,6 +29,12 @@
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-ai</artifactId>
         </dependency>
+
+        <!-- https://github.com/piotr-j/bte2 -->
+        <dependency>
+            <groupId>com.github.piotr-j.bte2</groupId>
+            <artifactId>bte</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/com/mygdx/game/GameStage.java
+++ b/core/src/com/mygdx/game/GameStage.java
@@ -234,8 +234,8 @@ public class GameStage extends Stage implements Observable {
 		}
 
 		@Override
-		public boolean scrolled(int amount) {
-			cameraController.processZoom(amount);
+		public boolean scrolled(float amountX, float amountY) {
+			cameraController.processZoom(amountY);
 			return true;
 		}
 

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-bullet-platform</artifactId>
+            <classifier>natives-desktop</classifier>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-platform</artifactId>
             <classifier>natives-desktop</classifier>
         </dependency>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.mygdx.game</groupId>
+        <artifactId>gdx-demo-3d</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>desktop</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+    </build>
+</project>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -13,6 +13,19 @@
     <artifactId>desktop</artifactId>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <!-- https://github.com/antivoland/GdxDemo3D -->
+        <dependency>
+            <groupId>com.mygdx.game</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-backend-lwjgl</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <sourceDirectory>src</sourceDirectory>
     </build>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -39,5 +39,11 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>../android/assets</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -20,9 +20,15 @@
             <artifactId>core</artifactId>
         </dependency>
 
+        <!-- https://github.com/libgdx/libgdx -->
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-backend-lwjgl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-platform</artifactId>
+            <classifier>natives-desktop</classifier>
         </dependency>
     </dependencies>
 

--- a/ios/pom.xml
+++ b/ios/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.mygdx.game</groupId>
+        <artifactId>gdx-demo-3d</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ios</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+    </build>
+</project>

--- a/ios/pom.xml
+++ b/ios/pom.xml
@@ -14,10 +14,26 @@
     <packaging>jar</packaging>
 
     <dependencies>
+        <!-- https://github.com/antivoland/GdxDemo3D -->
+        <dependency>
+            <groupId>com.mygdx.game</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
+
+        <!-- https://github.com/libgdx/libgdx -->
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-backend-robovm</artifactId>
+        </dependency>
+
         <!-- https://github.com/MobiVM/robovm -->
         <dependency>
             <groupId>com.mobidevelop.robovm</groupId>
             <artifactId>robovm-cocoatouch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mobidevelop.robovm</groupId>
+            <artifactId>robovm-rt</artifactId>
         </dependency>
     </dependencies>
 

--- a/ios/pom.xml
+++ b/ios/pom.xml
@@ -13,6 +13,14 @@
     <artifactId>ios</artifactId>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <!-- https://github.com/MobiVM/robovm -->
+        <dependency>
+            <groupId>com.mobidevelop.robovm</groupId>
+            <artifactId>robovm-cocoatouch</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <sourceDirectory>src</sourceDirectory>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             </dependency>
             <dependency>
                 <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-bullet-platform</artifactId>
+                <version>${gdx.version}</version>
+                <classifier>natives-desktop</classifier>
+            </dependency>
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
                 <artifactId>gdx-platform</artifactId>
                 <version>${gdx.version}</version>
                 <classifier>natives-desktop</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
     <modules>
         <module>android</module>
+        <module>core</module>
         <module>desktop</module>
         <module>ios</module>
     </modules>
@@ -21,12 +22,46 @@
 
         <java.version>11</java.version>
 
+        <gdx.version>1.11.0</gdx.version>
+        <gdx-ai.version>1.8.2</gdx-ai.version>
+
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     </properties>
 
     <dependencyManagement>
-        <dependencies/>
+        <dependencies>
+            <!-- https://github.com/antivoland/GdxDemo3D -->
+            <dependency>
+                <groupId>com.mygdx.game</groupId>
+                <artifactId>core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- https://github.com/libgdx/libgdx -->
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx</artifactId>
+                <version>${gdx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-backend-android</artifactId>
+                <version>${gdx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-bullet</artifactId>
+                <version>${gdx.version}</version>
+            </dependency>
+
+            <!-- https://github.com/libgdx/gdx-ai -->
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-ai</artifactId>
+                <version>${gdx-ai.version}</version>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mygdx.game</groupId>
+    <artifactId>gdx-demo-3d</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>android</module>
+        <module>desktop</module>
+        <module>ios</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <java.version>11</java.version>
+
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies/>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 
         <gdx.version>1.11.0</gdx.version>
         <gdx-ai.version>1.8.2</gdx-ai.version>
+        <bte.version>0.7.1</bte.version>
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
@@ -61,8 +62,22 @@
                 <artifactId>gdx-ai</artifactId>
                 <version>${gdx-ai.version}</version>
             </dependency>
+
+            <!-- https://github.com/piotr-j/bte2 -->
+            <dependency>
+                <groupId>com.github.piotr-j.bte2</groupId>
+                <artifactId>bte</artifactId>
+                <version>${bte.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,9 @@
         <android.version>4.1.1.4</android.version>
         <robovm.version>2.3.18</robovm.version>
 
-        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
-        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-dependency-plugin.version>3.4.0</maven-dependency-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -55,6 +56,11 @@
             <dependency>
                 <groupId>com.badlogicgames.gdx</groupId>
                 <artifactId>gdx-backend-lwjgl</artifactId>
+                <version>${gdx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-backend-robovm</artifactId>
                 <version>${gdx.version}</version>
             </dependency>
             <dependency>
@@ -90,6 +96,11 @@
                 <artifactId>robovm-cocoatouch</artifactId>
                 <version>${robovm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.mobidevelop.robovm</groupId>
+                <artifactId>robovm-rt</artifactId>
+                <version>${robovm.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -105,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.plugin.version}</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${java.version}</release>
                 </configuration>
@@ -114,13 +125,30 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${maven.source.plugin.version}</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <gdx.version>1.11.0</gdx.version>
         <gdx-ai.version>1.8.2</gdx-ai.version>
         <bte.version>0.7.1</bte.version>
+        <android.version>4.1.1.4</android.version>
+        <robovm.version>2.3.18</robovm.version>
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
@@ -52,6 +54,11 @@
             </dependency>
             <dependency>
                 <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-backend-lwjgl</artifactId>
+                <version>${gdx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
                 <artifactId>gdx-bullet</artifactId>
                 <version>${gdx.version}</version>
             </dependency>
@@ -68,6 +75,20 @@
                 <groupId>com.github.piotr-j.bte2</groupId>
                 <artifactId>bte</artifactId>
                 <version>${bte.version}</version>
+            </dependency>
+
+            <!-- http://source.android.com -->
+            <dependency>
+                <groupId>com.google.android</groupId>
+                <artifactId>android</artifactId>
+                <version>${android.version}</version>
+            </dependency>
+
+            <!-- https://github.com/MobiVM/robovm -->
+            <dependency>
+                <groupId>com.mobidevelop.robovm</groupId>
+                <artifactId>robovm-cocoatouch</artifactId>
+                <version>${robovm.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
                 <artifactId>gdx-bullet</artifactId>
                 <version>${gdx.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.badlogicgames.gdx</groupId>
+                <artifactId>gdx-platform</artifactId>
+                <version>${gdx.version}</version>
+                <classifier>natives-desktop</classifier>
+            </dependency>
 
             <!-- https://github.com/libgdx/gdx-ai -->
             <dependency>


### PR DESCRIPTION
Stuck with the import:

```
Server returned HTTP response code: 403 for URL: http://services.gradle.org/distributions/gradle-2.4-all.zip
```

I also see pretty many win-related logic in the build scripts and think about a thin maven infra around the game. It will make possible to run the apps, tools etc. by casting an ancient magic [as](https://github.com/antivoland/console-viewport) follows:

```
mvn exec:java -Dexec.mainClass="com.mygdx.game.desktop.DesktopLauncher"
```

**Pros:** TBD
**Cons:** N+1 pom files overhead